### PR TITLE
[FEAT] Use winston logger when calling Algoan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,11 +42,25 @@
       "integrity": "sha512-OHloDPdHm2X6tNnO9WKMDKohpmL99LMvvK65EKYvamIWcMP5K1itO6iHt5o96dJJqy58sQSIr4VOugIKrkQXkg=="
     },
     "@algoan/rest": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@algoan/rest/-/rest-1.11.0.tgz",
-      "integrity": "sha512-ge0ch3idQwl59Ix2R/E2lge6DhYVyT3tonY7GZ6uPJKoUcqNW8WdZOFShHJ4CwPF7WFavldA44nNiUkUoud+jw==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@algoan/rest/-/rest-1.17.2.tgz",
+      "integrity": "sha512-esGst2aXuqA5CavIOuJs0nvLAUXLE4Jcz8jhfY9LQr9Qilgk/OhTpBRcBdtfXWfD5w8C3ebLnMMw9NAn2aoW8g==",
       "requires": {
-        "axios": "^0.19.2"
+        "axios": "^0.19.2",
+        "form-data": "^3.0.0",
+        "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@angular-devkit/core": {
@@ -3443,8 +3457,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -4496,7 +4509,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -5519,8 +5531,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@algoan/nestjs-http-exception-filter": "^1.0.4",
     "@algoan/nestjs-logging-interceptor": "^2.1.2",
-    "@algoan/rest": "^1.11.0",
+    "@algoan/rest": "^1.17.2",
     "@nestjs/common": "^7.4.2",
     "@nestjs/core": "^7.4.2",
     "@nestjs/platform-express": "^7.4.2",

--- a/test/utils/app.ts
+++ b/test/utils/app.ts
@@ -50,7 +50,9 @@ export const buildFakeApp = async (): Promise<INestApplication> => {
     baseUrl: fakeAlgoanBaseUrl,
     method: 'get',
     result: [],
-    path: '/v1/subscriptions',
+    path: `/v1/subscriptions?filter=${JSON.stringify({
+      eventName: { $in: config.eventList },
+    })}`,
   });
   const fakePostSubscriptions: nock.Scope = fakeAPI({
     baseUrl: fakeAlgoanBaseUrl,


### PR DESCRIPTION
### Description

- Set @algoan/rest to use the same Winston Logger config than the rest of the connector

### Note

- The `format` option in non-production mode is not the same than the one in `main.ts`. I don't know which format is better.
- ~~I think I need to update the `package-lock.json`. I've update node to 15.0.1, since then whenever I run `npm install` each `package-lock.json` are updated in huge size.~~ Went back to node lts/erbium and rebased.