### PR TITLE
[FEAT] Update Subscription event's status

### DIFF
--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -1,4 +1,4 @@
-import { ServiceAccount } from '@algoan/rest';
+import { EventName, EventStatus, ServiceAccount, Subscription, SubscriptionEvent } from '@algoan/rest';
 import { UnauthorizedException, Injectable } from '@nestjs/common';
 
 import { AlgoanService } from '../../algoan/algoan.service';
@@ -25,6 +25,52 @@ export class HooksService {
       throw new UnauthorizedException(`No service account found for subscription ${event.subscription.id}`);
     }
 
+    const subscription: Subscription | undefined = serviceAccount.subscriptions.find(
+      (sub: Subscription) => sub.id === event.subscription.id,
+    );
+
+    if (subscription === undefined) {
+      return;
+    }
+
+    if (!subscription.validateSignature(signature, (event.payload as unknown) as { [key: string]: string })) {
+      throw new UnauthorizedException('Invalid X-Hub-Signature: you cannot call this API');
+    }
+
+    // Handle the event asynchronously
+    void this.dispatchAndHandleWebhook(event, subscription);
+
     return;
   }
+
+  /**
+   * Dispatch to the right webhook handler and handle
+   *
+   * Allow to asynchronously handle (with `void`) the webhook and firstly respond 204 to the server
+   */
+  private readonly dispatchAndHandleWebhook = async (event: EventDTO, subscription: Subscription): Promise<void> => {
+    // ACKnowledge the subscription event
+    const se: SubscriptionEvent = subscription.event(event.id);
+
+    try {
+      switch (event.subscription.eventName) {
+        // TODO handle your events here
+        case 'example' as EventName:
+          // Handle the event example
+          break;
+
+        // The default case should never be reached, as the eventName is already checked in the DTO
+        default:
+          void se.update({ status: EventStatus.FAILED });
+
+          return;
+      }
+    } catch (err) {
+      void se.update({ status: EventStatus.ERROR });
+
+      throw err;
+    }
+
+    void se.update({ status: EventStatus.PROCESSED });
+  };
 }


### PR DESCRIPTION
### Description

- Update SubscriptionEvent status at:
  - Start of process: `ACK` (done automatically upon. receiving the response `204 NO CONTENT`)
  - End of process: `PROCESSED`
  - Error: `ERROR`
  - Failure: `FAILED`

### Reference

- Documentation [PATCH Resthook Subscription Event](https://developers.algoan.com/api#operation/patchResthookSubEvents)